### PR TITLE
Change sidebar title to a link

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import Signin from './AccountBarBtn';
 import { SessionProvider } from 'next-auth/react';
 import MenuList from './SideMenuList';
+import Link from 'next/link';
 
 const drawerWidth = 240;
 
@@ -109,7 +110,9 @@ export default function Sidebar({ children }: Readonly<{ children: React.ReactNo
                         <MenuIcon />
                     </IconButton>
                     <Typography variant="h5" sx={{ fontWeight: 'bold' }} noWrap component="div">
-                        Linkle
+                        <Link href="/" passHref>
+                            Linkle
+                        </Link>
                     </Typography>
                     <div style={{ flexGrow: 1 }}></div>
                     <SessionProvider>


### PR DESCRIPTION
Update the sidebar title to be a clickable link, enhancing navigation within the application.

Resolved #33