### PR TITLE
Fix login check implementation for email authentication

### DIFF
--- a/src/lib/server/club.ts
+++ b/src/lib/server/club.ts
@@ -11,8 +11,10 @@ export const getClubById = async (
 ): Promise<Club | fetchErrorResponse> => {
   try {
     const email = (await auth())?.user?.email;
-    if (!email) return "unauthorized";
-    const apiKey = CryptoJS.AES.encrypt(email, process.env.API_ROUTE_SECRET as string).toString();
+    const apiKey = CryptoJS.AES.encrypt(
+      email ?? "No Auth",
+      process.env.API_ROUTE_SECRET as string
+    ).toString();
     const res = await fetch(`${apiBase}/api/clubs/${id}`, {
       headers: new Headers({
         Cookie: sessionID ?? "",


### PR DESCRIPTION
Correct the handling of cases where the email is not available during login checks. The code now encrypts a default value instead of returning unauthorized.