### PR TITLE
Replace sessionID with email in Club component for improved authentication management

### DIFF
--- a/src/app/clubs/[...slug]/page.tsx
+++ b/src/app/clubs/[...slug]/page.tsx
@@ -77,6 +77,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string[
     headersData.get("x-forwarded-proto") ?? host?.startsWith("localhost") ? "http" : "https";
   const cookie = headersData.get("cookie");
   const sessionID = cookie?.split(";").find((c) => c.trim().startsWith("authjs.session-token"));
+  const email = (await auth())?.user?.email;
   const apiBase = `${protocol}://${host}`;
   const slug = (await params).slug;
   switch (slug[1]) {
@@ -125,7 +126,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string[
             <ClubPage
               id={slug[0]}
               apiBase={apiBase}
-              sessionID={sessionID}
+              email={email || undefined}
             />
           </Suspense>
         </Stack>

--- a/src/components/clubPage/main.tsx
+++ b/src/components/clubPage/main.tsx
@@ -12,13 +12,13 @@ import { forbidden, notFound, unauthorized } from "next/navigation";
 export default function Club({
   id,
   apiBase,
-  sessionID,
+  email,
 }: {
   id: string;
   apiBase: string;
-  sessionID: string | undefined;
+  email: string | undefined;
 }) {
-  const club = use(getClubById(id, apiBase, sessionID));
+  const club = use(getClubById(id, apiBase, email));
   if (club == "forbidden") forbidden();
   if (club == "notfound") notFound();
   if (club == "unauthorized") unauthorized();
@@ -59,7 +59,7 @@ export default function Club({
                 club.long_description == "" ? "# 説明はありません。" : club.long_description
               }
             />
-            {sessionID == undefined ? null : (
+            {email == undefined ? null : (
               <LongDescription
                 description={
                   `# Slack` +


### PR DESCRIPTION
Update the Club component to use email instead of sessionID for managing authentication information. This change enhances the handling of user credentials.