### PR TITLE
Fix position of beta participation link in sidebar menu

### DIFF
--- a/src/components/Sidebar/SideMenuList.tsx
+++ b/src/components/Sidebar/SideMenuList.tsx
@@ -32,14 +32,14 @@ export default function MenuList() {
       icon: <GroupsIcon />,
     },
     {
-      label: "ベータ版への参加",
-      href: "/beta",
-      icon: <BiotechIcon />,
-    },
-    {
       label: "イベント一覧",
       href: "/events",
       icon: <EventIcon />,
+    },
+    {
+      label: "ベータ版への参加",
+      href: "/beta",
+      icon: <BiotechIcon />,
     },
     /*{
             label: 'ユーザー一覧',


### PR DESCRIPTION
Adjust the placement of the beta participation link within the sidebar menu for improved visibility.